### PR TITLE
Put code in constructor instead of static initializer

### DIFF
--- a/brut-components/src/main/java/org/bloomreach/forge/brut/components/SimpleComponentTest.java
+++ b/brut-components/src/main/java/org/bloomreach/forge/brut/components/SimpleComponentTest.java
@@ -45,7 +45,7 @@ public class SimpleComponentTest {
     protected MockComponentManager componentManager = new MockComponentManager();
     protected MockContainerConfiguration containerConfiguration = componentManager.getContainerConfiguration();
 
-    static {
+    public SimpleComponentTest() {
         HstServices.setComponentManager(delegatingComponentManager);
     }
 


### PR DESCRIPTION
Put code in constructor instead of static initializer because other testclasses might set their own componentmanager