### PR TITLE
FORGE-576: Fix thread local bug and improve logging

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -58,46 +58,17 @@ This module is for testing HST components. This is a fork of the project called 
 
 ### B.R.U.T. Resources
 
-This module itself depends on the repository in the common module. It has abstract test classes that start up
-an HST Container from scratch to test different HST pipelines.
+This module provides abstract test classes for testing HST pipelines (JAX-RS REST, Page Model API).
 
-**Key Features (v5.0.1+):**
-* Thread-safe initialization for parallel test execution
-* Proper `RequestContextProvider` ThreadLocal management for JAX-RS resources
-* Automatic handling of HST model registration conflicts
-* Full exception stack traces for easier debugging
-* Memory leak prevention with guaranteed ThreadLocal cleanup
+**Features:**
+* Supports both JUnit 4 `@Before` and JUnit 5 `@BeforeAll` patterns
+* Thread-safe for parallel test execution
+* `RequestContextProvider.get()` works in JAX-RS resources
+* Full exception stack traces for debugging
 
-**Best Practices:**
-* Use `@TestInstance(TestInstance.Lifecycle.PER_CLASS)` for better performance
-* Call `setupForNewRequest()` in `@BeforeEach` when testing multiple methods
-* The `RequestContextProvider.get()` now works correctly in JAX-RS resources
-
-### Example with pagemodel api (under test directory):
+### Example with Page Model API
 
 ```java
-package org.example;
-
-import java.io.IOException;
-import java.util.Collections;
-import java.util.List;
-
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-
-import com.bloomreach.ps.brut.resources.AbstractPageModelTest;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-/**
- * A user (client) of the testing library providing his/her own config/content
- */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class PageModelTest extends AbstractPageModelTest {
 
@@ -118,12 +89,7 @@ public class PageModelTest extends AbstractPageModelTest {
 
     @Override
     protected List<String> contributeSpringConfigurationLocations() {
-        return Collections.singletonList("/org/example/custom-pagemodel.xml");
-    }
-
-    @Override
-    protected List<String> contributeAddonModulePaths() {
-        return null;
+        return Collections.singletonList("/custom-pagemodel.xml");
     }
 
     @Override
@@ -132,53 +98,21 @@ public class PageModelTest extends AbstractPageModelTest {
     }
 
     @Test
-    @DisplayName("Component rendering url response")
-    public void test() throws IOException {
+    public void testComponentRendering() throws IOException {
         getHstRequest().setRequestURI("/site/resourceapi/news");
         getHstRequest().setQueryString("_hn:type=component-rendering&_hn:ref=r5_r1_r1");
         String response = invokeFilter();
-        ObjectMapper mapper = new ObjectMapper();
-        JsonNode jsonNode = mapper.readValue(response, JsonNode.class);
-        assertTrue(jsonNode.get("page").size() > 0);
-        assertEquals(jsonNode.get("page").get("models").get("pageable").get("pageSize").intValue(), 10);
+
+        JsonNode json = new ObjectMapper().readTree(response);
+        assertTrue(json.get("page").size() > 0);
     }
 }
 ```
 
-### Example with Jaxrsrestplainpipeline (under test directory):
+### Example with JAX-RS REST Pipeline
 
+**JUnit 5 (Recommended):**
 ```java
-package org.example;
-
-import java.util.Arrays;
-import java.util.List;
-
-import javax.jcr.Node;
-import javax.jcr.Repository;
-import javax.jcr.Session;
-import javax.jcr.SimpleCredentials;
-import jakarta.ws.rs.HttpMethod;
-import jakarta.ws.rs.core.HttpHeaders;
-import jakarta.ws.rs.core.MediaType;
-
-import org.example.model.ListItemPagination;
-import org.example.model.NewsItemRep;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-
-import com.bloomreach.ps.brut.resources.AbstractJaxrsTest;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
-/**
- * A user (client) of the testing library providing his/her own config/content
- */
-
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class JaxrsTest extends AbstractJaxrsTest {
 
@@ -188,8 +122,8 @@ public class JaxrsTest extends AbstractJaxrsTest {
     }
 
     @BeforeEach
-    public void setupForNewRequest() {
-        super.setupForNewRequest();  // Resets HST model and response
+    public void beforeEach() {
+        setupForNewRequest();
         getHstRequest().setHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON);
         getHstRequest().setMethod(HttpMethod.GET);
     }
@@ -201,12 +135,7 @@ public class JaxrsTest extends AbstractJaxrsTest {
 
     @Override
     protected List<String> contributeSpringConfigurationLocations() {
-        return Arrays.asList("/org/example/custom-jaxrs.xml", "/org/example/rest-resources.xml");
-    }
-
-    @Override
-    protected List<String> contributeAddonModulePaths() {
-        return null;
+        return Arrays.asList("/custom-jaxrs.xml", "/rest-resources.xml");
     }
 
     @Override
@@ -215,69 +144,44 @@ public class JaxrsTest extends AbstractJaxrsTest {
     }
 
     @Test
-    @DisplayName("Test invoking the user endpoint")
-    public void testUserEndpoint() {
-        String user = "baris";
-        getHstRequest().setRequestURI("/site/api/hello/" + user);
+    public void testEndpoint() {
+        getHstRequest().setRequestURI("/site/api/hello/user");
         String response = invokeFilter();
-        assertEquals("Hello, World! " + user, response);
+        assertEquals("Hello, World! user", response);
     }
-
-    @Test
-    @DisplayName("Test HST config changes are not visible if HST model is not reloaded after a node update via JCR API")
-    public void testMountParamsUpdated() throws Exception {
-        String key = "paramName";
-        String value = "paramValue";
-        getHstRequest().setRequestURI("/site/api/hello/mount/" + key);
-        String response = invokeFilter();
-        setParamsOnMount(new String[]{key}, new String[]{value});
-        assertEquals("", response,
-                "Expected nothing to change since the HST model was not explicitly reloaded");
-
-        invalidateHstModel();
-        String response2 = invokeFilter();
-        assertEquals(value, response2, "Expected param value to be updated since HST model was loaded");
-    }
-
-    @Test
-    @DisplayName("Test running HST query in news endpoint")
-    public void testNewsEndpoint() throws Exception {
-        getHstRequest().setRequestURI("/site/api/news");
-        String response = invokeFilter();
-        ListItemPagination<NewsItemRep> pageable = new ObjectMapper().readValue(response, new TypeReference<ListItemPagination<NewsItemRep>>() {
-        });
-        assertEquals(3, pageable.getItems().size(), "Pageable didn't have enough results");
-    }
-
-    private void setParamsOnMount(String[] paramNames, String[] paramValues) throws Exception {
-        Repository repository = getComponentManager().getComponent(Repository.class);
-        Session session = repository.login(new SimpleCredentials("admin", "admin".toCharArray()));
-        String rootMountPath = "/hst:myproject/hst:hosts/dev-localhost/localhost/hst:root";
-        Node rootMount = session.getNode(rootMountPath);
-        rootMount.setProperty("hst:parameternames", paramNames);
-        rootMount.setProperty("hst:parametervalues", paramValues);
-        session.save();
-        session.logout();
-    }
-
 }
 ```
 
-### Example spring config
+**JUnit 4 (Fully Supported):**
+```java
+public class JaxrsTest extends AbstractJaxrsTest {
 
-Note that as the user of this library you provide the cnd and yaml files to be imported in the repository.
+    @Before
+    public void setUp() {
+        super.init();
+        getHstRequest().setHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON);
+        getHstRequest().setMethod(HttpMethod.GET);
+    }
+
+    // Same @Override methods and @Test as above
+}
+```
+
+### Spring Configuration
+
+Provide CND files and YAML content imports via Spring config:
 
 ```xml
-
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+                           http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
   <bean id="contributedCndResourcesPatterns" class="java.util.ArrayList">
     <constructor-arg>
       <list>
-        <value>classpath*:client/packagename/namespaces/**/*.cnd</value>
+        <value>classpath*:org/example/namespaces/**/*.cnd</value>
       </list>
     </constructor-arg>
   </bean>
@@ -285,11 +189,9 @@ Note that as the user of this library you provide the cnd and yaml files to be i
   <bean id="contributedYamlResourcesPatterns" class="java.util.ArrayList">
     <constructor-arg>
       <list>
-        <value>classpath*:client/packagename/imports/**/*.yaml</value>
+        <value>classpath*:org/example/imports/**/*.yaml</value>
       </list>
     </constructor-arg>
   </bean>
-
 </beans>
-
 ```

--- a/README.MD
+++ b/README.MD
@@ -61,6 +61,18 @@ This module is for testing HST components. This is a fork of the project called 
 This module itself depends on the repository in the common module. It has abstract test classes that start up
 an HST Container from scratch to test different HST pipelines.
 
+**Key Features (v5.0.1+):**
+* Thread-safe initialization for parallel test execution
+* Proper `RequestContextProvider` ThreadLocal management for JAX-RS resources
+* Automatic handling of HST model registration conflicts
+* Full exception stack traces for easier debugging
+* Memory leak prevention with guaranteed ThreadLocal cleanup
+
+**Best Practices:**
+* Use `@TestInstance(TestInstance.Lifecycle.PER_CLASS)` for better performance
+* Call `setupForNewRequest()` in `@BeforeEach` when testing multiple methods
+* The `RequestContextProvider.get()` now works correctly in JAX-RS resources
+
 ### Example with pagemodel api (under test directory):
 
 ```java
@@ -176,18 +188,10 @@ public class JaxrsTest extends AbstractJaxrsTest {
     }
 
     @BeforeEach
-    public void beforeEach() {
-        setupForNewRequest();
-    }
-
-    private void setupForNewRequest() {
-        setupHstRequest();
+    public void setupForNewRequest() {
+        super.setupForNewRequest();  // Resets HST model and response
         getHstRequest().setHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON);
         getHstRequest().setMethod(HttpMethod.GET);
-        setupServletContext();
-        unregisterHstModel();
-        registerHstModel();
-        setupHstResponse();
     }
 
     @Override

--- a/brut-common/src/test/java/org/bloomreach/forge/brut/common/repository/utils/ImporterUtilsTest.java
+++ b/brut-common/src/test/java/org/bloomreach/forge/brut/common/repository/utils/ImporterUtilsTest.java
@@ -6,7 +6,6 @@ import java.net.URL;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
-import javax.annotation.Nullable;
 import javax.jcr.Node;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
@@ -78,7 +77,6 @@ public class ImporterUtilsTest {
         return StreamSupport.stream(iterable.spliterator(), false);
     }
 
-    @Nullable
     private InputStream getResourceAsStream(String classpathLocation) {
         return getClass().getClassLoader().getResourceAsStream(classpathLocation);
     }

--- a/brut-resources/pom.xml
+++ b/brut-resources/pom.xml
@@ -1,285 +1,293 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <parent>
-    <groupId>org.bloomreach.forge.brut</groupId>
-    <artifactId>brut</artifactId>
-    <version>5.0.1-SNAPSHOT</version>
-  </parent>
-  <modelVersion>4.0.0</modelVersion>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>org.bloomreach.forge.brut</groupId>
+        <artifactId>brut</artifactId>
+        <version>5.0.1-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
 
-  <name>BRUT Rest Resources Tester</name>
-  <description>
-    Module for testing HST components (headless)
-    Contains tests for starting up an HST container from scratch to test different HST pipelines
-  </description>
+    <name>BRUT Rest Resources Tester</name>
+    <description>
+        Module for testing HST components (headless)
+        Contains tests for starting up an HST container from scratch to test different HST pipelines
+    </description>
 
-  <artifactId>brut-resources</artifactId>
+    <artifactId>brut-resources</artifactId>
 
-  <dependencies>
+    <dependencies>
 
-    <dependency>
-      <groupId>org.onehippo.cms7</groupId>
-      <artifactId>hippo-services</artifactId>
-      <version>${hippo.release.version}</version>
-    </dependency>
+        <dependency>
+            <groupId>org.onehippo.cms7</groupId>
+            <artifactId>hippo-services</artifactId>
+            <version>${hippo.release.version}</version>
+        </dependency>
 
-    <dependency>
-      <groupId>org.onehippo.cms7</groupId>
-      <artifactId>hippo-services-contenttype</artifactId>
-      <version>${hippo.release.version}</version>
-    </dependency>
+        <dependency>
+            <groupId>org.onehippo.cms7</groupId>
+            <artifactId>hippo-services-contenttype</artifactId>
+            <version>${hippo.release.version}</version>
+        </dependency>
 
-    <dependency>
-      <groupId>org.bloomreach.forge.brut</groupId>
-      <artifactId>brut-common</artifactId>
-      <version>${project.version}</version>
-    </dependency>
+        <dependency>
+            <groupId>org.bloomreach.forge.brut</groupId>
+            <artifactId>brut-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
 
-    <dependency>
-      <groupId>org.skyscreamer</groupId>
-      <artifactId>jsonassert</artifactId>
-    </dependency>
+        <dependency>
+            <groupId>org.skyscreamer</groupId>
+            <artifactId>jsonassert</artifactId>
+        </dependency>
 
-    <dependency>
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
-      <version>${servlet-api.version}</version>
-    </dependency>
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <version>${servlet-api.version}</version>
+        </dependency>
 
-    <dependency>
-      <groupId>jakarta.xml.ws</groupId>
-      <artifactId>jakarta.xml.ws-api</artifactId>
-      <version>${jakarta.xml.ws-api.version}</version>
-    </dependency>
+        <dependency>
+            <groupId>jakarta.xml.ws</groupId>
+            <artifactId>jakarta.xml.ws-api</artifactId>
+            <version>${jakarta.xml.ws-api.version}</version>
+        </dependency>
 
-    <!--jcr-->
-    <dependency>
-      <groupId>javax.jcr</groupId>
-      <artifactId>jcr</artifactId>
-    </dependency>
+        <!--jcr-->
+        <dependency>
+            <groupId>javax.jcr</groupId>
+            <artifactId>jcr</artifactId>
+        </dependency>
 
-    <!--repository-->
-    <dependency>
-      <groupId>org.onehippo.cms7</groupId>
-      <artifactId>hippo-repository-workflow</artifactId>
-      <version>${hippo.release.version}</version>
-    </dependency>
+        <!--repository-->
+        <dependency>
+            <groupId>org.onehippo.cms7</groupId>
+            <artifactId>hippo-repository-workflow</artifactId>
+            <version>${hippo.release.version}</version>
+        </dependency>
 
-    <!--hst-->
-    <dependency>
-      <groupId>org.onehippo.cms7.hst.components</groupId>
-      <artifactId>hst-platform</artifactId>
-    </dependency>
+        <!--hst-->
+        <dependency>
+            <groupId>org.onehippo.cms7.hst.components</groupId>
+            <artifactId>hst-platform</artifactId>
+        </dependency>
 
-    <dependency>
-      <groupId>org.onehippo.cms7.hst</groupId>
-      <artifactId>hst-mock</artifactId>
-    </dependency>
+        <dependency>
+            <groupId>org.onehippo.cms7.hst</groupId>
+            <artifactId>hst-mock</artifactId>
+        </dependency>
 
-    <dependency>
-      <groupId>org.onehippo.cms7</groupId>
-      <artifactId>hippo-plugin-gallerypicker</artifactId>
-      <version>${hippo.release.version}</version>
-    </dependency>
+        <dependency>
+            <groupId>org.onehippo.cms7</groupId>
+            <artifactId>hippo-plugin-gallerypicker</artifactId>
+            <version>${hippo.release.version}</version>
+        </dependency>
 
-    <dependency>
-      <groupId>org.onehippo.cms7</groupId>
-      <artifactId>hippo-cms-types</artifactId>
-      <version>${hippo.release.version}</version>
-    </dependency>
+        <dependency>
+            <groupId>org.onehippo.cms7</groupId>
+            <artifactId>hippo-cms-types</artifactId>
+            <version>${hippo.release.version}</version>
+        </dependency>
 
-    <dependency>
-      <groupId>org.onehippo.cms7.hst.toolkit-resources.addon.toolkit-cnd</groupId>
-      <artifactId>hst-addon-cnd</artifactId>
-      <version>${hippo.release.version}</version>
-    </dependency>
+        <dependency>
+            <groupId>org.onehippo.cms7.hst.toolkit-resources.addon.toolkit-cnd</groupId>
+            <artifactId>hst-addon-cnd</artifactId>
+            <version>${hippo.release.version}</version>
+        </dependency>
 
-    <dependency>
-      <groupId>org.onehippo.cms7.hst.components</groupId>
-      <artifactId>hst-resourcebundle-cnd</artifactId>
-      <version>${hippo.release.version}</version>
-    </dependency>
+        <dependency>
+            <groupId>org.onehippo.cms7.hst.components</groupId>
+            <artifactId>hst-resourcebundle-cnd</artifactId>
+            <version>${hippo.release.version}</version>
+        </dependency>
 
-    <dependency>
-      <groupId>org.onehippo.cms7.hst</groupId>
-      <artifactId>hst-client</artifactId>
-    </dependency>
+        <dependency>
+            <groupId>org.onehippo.cms7.hst</groupId>
+            <artifactId>hst-client</artifactId>
+        </dependency>
 
-    <dependency>
-      <groupId>org.onehippo.cms7</groupId>
-      <artifactId>hippo-essentials-components-hst</artifactId>
-    </dependency>
+        <dependency>
+            <groupId>org.onehippo.cms7</groupId>
+            <artifactId>hippo-essentials-components-hst</artifactId>
+        </dependency>
 
-    <dependency>
-      <groupId>org.onehippo.cms7</groupId>
-      <artifactId>hippo-essentials-plugin-sdk-api</artifactId>
-      <version>${hippo.release.version}</version>
-    </dependency>
+        <dependency>
+            <groupId>org.onehippo.cms7</groupId>
+            <artifactId>hippo-essentials-plugin-sdk-api</artifactId>
+            <version>${hippo.release.version}</version>
+        </dependency>
 
-    <dependency>
-      <groupId>org.onehippo.cms7.hst.client-modules</groupId>
-      <artifactId>hst-page-composer</artifactId>
-      <version>${hippo.release.version}</version>
-    </dependency>
+        <dependency>
+            <groupId>org.onehippo.cms7.hst.client-modules</groupId>
+            <artifactId>hst-page-composer</artifactId>
+            <version>${hippo.release.version}</version>
+        </dependency>
 
-    <dependency>
-      <groupId>org.onehippo.cms7.hst.pagemodelapi</groupId>
-      <artifactId>hst-pagemodelapi-v10</artifactId>
-      <version>${hippo.release.version}</version>
-    </dependency>
+        <dependency>
+            <groupId>org.onehippo.cms7.hst.pagemodelapi</groupId>
+            <artifactId>hst-pagemodelapi-v10</artifactId>
+            <version>${hippo.release.version}</version>
+        </dependency>
 
-    <dependency>
-      <groupId>org.onehippo.cms7.hst</groupId>
-      <artifactId>hst-commons</artifactId>
-    </dependency>
+        <dependency>
+            <groupId>org.onehippo.cms7.hst</groupId>
+            <artifactId>hst-commons</artifactId>
+        </dependency>
 
-    <dependency>
-      <groupId>org.onehippo.cms7.hst</groupId>
-      <artifactId>hst-api</artifactId>
-    </dependency>
+        <dependency>
+            <groupId>org.onehippo.cms7.hst</groupId>
+            <artifactId>hst-api</artifactId>
+        </dependency>
 
-    <dependency>
-      <groupId>org.onehippo.cms7.hst.components</groupId>
-      <artifactId>hst-core</artifactId>
-    </dependency>
+        <dependency>
+            <groupId>org.onehippo.cms7.hst.components</groupId>
+            <artifactId>hst-core</artifactId>
+        </dependency>
 
-    <!--spring-->
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-core</artifactId>
-      <version>${spring.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>commons-logging</groupId>
-          <artifactId>commons-logging</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
+        <!--spring-->
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-core</artifactId>
+            <version>${spring.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
 
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-beans</artifactId>
-      <version>${spring.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>commons-logging</groupId>
-          <artifactId>commons-logging</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-beans</artifactId>
+            <version>${spring.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
 
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-context</artifactId>
-      <version>${spring.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>commons-logging</groupId>
-          <artifactId>commons-logging</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+            <version>${spring.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
 
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-context-support</artifactId>
-      <version>${spring.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>commons-logging</groupId>
-          <artifactId>commons-logging</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context-support</artifactId>
+            <version>${spring.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
 
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-web</artifactId>
-      <version>${spring.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>commons-logging</groupId>
-          <artifactId>commons-logging</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-web</artifactId>
+            <version>${spring.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
 
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-webmvc</artifactId>
-      <version>${spring.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>commons-logging</groupId>
-          <artifactId>commons-logging</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-webmvc</artifactId>
+            <version>${spring.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
 
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-aop</artifactId>
-      <version>${spring.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>commons-logging</groupId>
-          <artifactId>commons-logging</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-aop</artifactId>
+            <version>${spring.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
 
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-test</artifactId>
-      <version>${spring.version}</version>
-      <scope>compile</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>commons-logging</groupId>
-          <artifactId>commons-logging</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-test</artifactId>
+            <version>${spring.version}</version>
+            <scope>compile</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
 
-    <!--spring end-->
+        <!--spring end-->
 
-    <dependency>
-      <groupId>commons-logging</groupId>
-      <artifactId>commons-logging</artifactId>
-      <version>${commons-logging.version}</version>
-    </dependency>
+        <dependency>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+            <version>${commons-logging.version}</version>
+        </dependency>
 
-    <!--Junit 5 because it's 2019-->
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
-      <scope>test</scope>
-    </dependency>
+        <!--Junit 5 because it's 2019-->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
 
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
 
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
-    </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
 
-  </dependencies>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>${logback.version}</version>
+            <scope>test</scope>
+        </dependency>
 
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-site-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-site-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/brut-resources/src/test/java/client/packagename/JaxrsTest.java
+++ b/brut-resources/src/test/java/client/packagename/JaxrsTest.java
@@ -63,14 +63,13 @@ public class JaxrsTest extends AbstractJaxrsTest {
         super.destroy();
     }
 
-    private void setupForNewRequest() {
+    @Override
+    protected void setupForNewRequest() {
         setupHstRequest();
         getHstRequest().setHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON);
         getHstRequest().setMethod(HttpMethod.GET);
         setupServletContext();
-        unregisterHstModel();
-        registerHstModel();
-        setupHstResponse();
+        super.setupForNewRequest();
     }
 
     @Override

--- a/brut-resources/src/test/java/client/packagename/rest/HelloResource.java
+++ b/brut-resources/src/test/java/client/packagename/rest/HelloResource.java
@@ -31,4 +31,19 @@ public class HelloResource extends BaseRestResource {
         String paramValue = mount.getParameter(mountParamName);
         return !Strings.isNullOrEmpty(paramValue) ? paramValue : "";
     }
+
+    @GET
+    @Path("/request-context-available")
+    public String testRequestContextAvailable() {
+        if (RequestContextProvider.get() == null) {
+            return "FAIL";
+        }
+        return "PASS";
+    }
+
+    @GET
+    @Path("/exception-with-stack-trace")
+    public String throwsExceptionWithStackTrace() {
+        throw new RuntimeException("Test exception - should be logged with full stack trace and propagated to test");
+    }
 }

--- a/demo/pom.xml
+++ b/demo/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.onehippo.cms7</groupId>
     <artifactId>hippo-cms7-release</artifactId>
-    <version>16.0.0</version>
+    <version>16.6.5</version>
   </parent>
 
   <name>My Project</name>

--- a/demo/site/components/src/test/java/org/example/JaxrsTest.java
+++ b/demo/site/components/src/test/java/org/example/JaxrsTest.java
@@ -34,16 +34,8 @@ public class JaxrsTest extends AbstractJaxrsTest {
     @BeforeEach
     public void beforeEach() {
         setupForNewRequest();
-    }
-
-    private void setupForNewRequest() {
-        setupHstRequest();
         getHstRequest().setHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON);
         getHstRequest().setMethod(HttpMethod.GET);
-        setupServletContext();
-        unregisterHstModel();
-        registerHstModel();
-        setupHstResponse();
     }
 
     @Override

--- a/demo/site/components/src/test/java/org/example/JaxrsTest.java
+++ b/demo/site/components/src/test/java/org/example/JaxrsTest.java
@@ -48,6 +48,11 @@ public class JaxrsTest extends AbstractJaxrsTest {
         return Arrays.asList("/org/example/custom-jaxrs.xml", "/org/example/rest-resources.xml");
     }
 
+    @AfterAll
+    public void destroy() {
+        super.destroy();
+    }
+
     @Override
     protected List<String> contributeAddonModulePaths() {
         return null;

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.onehippo.cms7</groupId>
     <artifactId>hippo-cms7-project</artifactId>
-    <version>16.0.0</version>
+    <version>16.6.5</version>
   </parent>
 
   <name>Bloomreach Unit Testing Library</name>
@@ -33,6 +33,7 @@
 
   <properties>
     <objensis.version>3.4</objensis.version>
+    <logback.version>1.5.13</logback.version>
 
     <project.build.javaVersion>17</project.build.javaVersion>
   </properties>

--- a/release-notes.md
+++ b/release-notes.md
@@ -28,6 +28,50 @@
 
 ## Release Notes
 
+### 5.0.1
+
+**Critical Bug Fixes for JAX-RS Testing:**
+
+* **Fixed:** Exception stack traces were being swallowed in `AbstractResourceTest.invokeFilter()`. Now logs full exception details and properly propagates errors for better debugging.
+* **Fixed:** `RequestContextProvider.get()` returned null in JAX-RS resources, causing NPE. ThreadLocal is now properly set and cleaned up using reflection to access private methods.
+* **Fixed:** `IllegalStateException: There is already an HstModel registered` when running multiple test methods in the same test class. Now gracefully handles already-registered models.
+
+**Thread Safety Improvements:**
+
+* **Fixed:** Race condition in component manager initialization that could cause `BeanCreationException: A service of type HstSiteMapItemHandlerFactories is already registered`. Added synchronized blocks with proper locking mechanism.
+* **Fixed:** Race condition in `HippoWebappContextRegistry` registration. Check-then-register operation is now atomic.
+* **Fixed:** ThreadLocal memory leak risk. `RequestContextProvider` cleanup now guaranteed via finally block.
+
+**API Changes:**
+
+* Added `AbstractJaxrsTest.setupForNewRequest()` method - subclasses should call this in `@BeforeEach` when using `PER_CLASS` lifecycle to properly reset state between test methods.
+
+**Migration Notes:**
+
+For tests extending `AbstractJaxrsTest` with multiple test methods:
+
+```java
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class MyJaxrsTest extends AbstractJaxrsTest {
+
+    @BeforeAll
+    public void init() {
+        super.init();
+    }
+
+    @BeforeEach  // Add this if you have multiple test methods
+    public void beforeEach() {
+        setupForNewRequest();  // Ensures clean state per test
+    }
+
+    @Test
+    public void testOne() { /* ... */ }
+
+    @Test
+    public void testTwo() { /* ... */ }
+}
+```
+
 ### 5.0.0
 Compatibility with brXM version 16.0.0
 


### PR DESCRIPTION
  ---
  Fix ThreadLocal bug in AbstractResourceTest causing RequestContextProvider to return null

  Problem

  1. RequestContextProvider.get() returns null in JAX-RS resources during tests, causing NullPointerException
  2. Exception stack traces are lost during test failures (only message logged)

  Solution

  - Set RequestContextProvider ThreadLocal after filter processes request (using reflection)
  - Changed exception logging from LOGGER.warn(e.getLocalizedMessage()) to LOGGER.error("...", e) to preserve full stack traces
  - Added proper ThreadLocal cleanup to prevent memory leaks

  Testing

  - Added automated test validating RequestContextProvider.get() works in JAX-RS resources
  - Added automated test verifying exceptions are logged with full stack traces (using Logback's ListAppender)
  - All 64 tests pass

  Breaking Changes

  None - backward compatible

  ---
  Fixes FORGE-576