### PR TITLE
Upgrade dependencies and migrate to updated library versions:

### DIFF
--- a/brut-components/src/main/java/org/bloomreach/forge/brut/components/AbstractRepoTest.java
+++ b/brut-components/src/main/java/org/bloomreach/forge/brut/components/AbstractRepoTest.java
@@ -1,6 +1,6 @@
 package org.bloomreach.forge.brut.components;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.bloomreach.forge.brut.common.repository.utils.ImporterUtils;
 import org.bloomreach.forge.brut.common.repository.utils.NodeTypeUtils;
 import org.bloomreach.forge.brut.components.exception.SetupTeardownException;

--- a/brut-components/src/main/java/org/bloomreach/forge/brut/components/mock/MockHstLink.java
+++ b/brut-components/src/main/java/org/bloomreach/forge/brut/components/mock/MockHstLink.java
@@ -1,14 +1,14 @@
 package org.bloomreach.forge.brut.components.mock;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.hippoecm.hst.core.component.HstComponentException;
 import org.hippoecm.hst.core.request.HstRequestContext;
 import org.hippoecm.hst.core.util.PathEncoder;
 
 import java.io.UnsupportedEncodingException;
 
-import static org.apache.commons.lang.CharEncoding.UTF_8;
-import static org.apache.commons.lang.StringUtils.EMPTY;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.hippoecm.hst.util.PathUtils.FULLY_QUALIFIED_URL_PREFIXES;
 
 public class MockHstLink extends org.hippoecm.hst.mock.core.linking.MockHstLink {
@@ -52,7 +52,7 @@ public class MockHstLink extends org.hippoecm.hst.mock.core.linking.MockHstLink 
             String result = null;
             for (String prefix : FULLY_QUALIFIED_URL_PREFIXES) {
                 if (getPath() != null && getPath().startsWith(prefix)) {
-                    result = PathEncoder.encode(getPath(), UTF_8, FULLY_QUALIFIED_URL_PREFIXES);
+                    result = PathEncoder.encode(getPath(), UTF_8.name(), FULLY_QUALIFIED_URL_PREFIXES);
                 }
             }
             return result;

--- a/brut-resources/src/main/resources/org/bloomreach/forge/brut/resources/hst/container.xml
+++ b/brut-resources/src/main/resources/org/bloomreach/forge/brut/resources/hst/container.xml
@@ -21,7 +21,7 @@
 
   <bean id="containerConfiguration" class="org.hippoecm.hst.core.container.ContainerConfigurationImpl">
     <constructor-arg>
-      <bean class="org.apache.commons.configuration.PropertiesConfiguration"/>
+      <bean class="org.apache.commons.configuration2.PropertiesConfiguration"/>
     </constructor-arg>
   </bean>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.onehippo.cms7</groupId>
         <artifactId>hippo-cms7-project</artifactId>
-        <version>16.6.5</version>
+        <version>16.7.0</version>
     </parent>
 
     <name>Bloomreach Unit Testing Library</name>


### PR DESCRIPTION
- Bump project parent version to 16.7.0 in `pom.xml`.
- Replace `org.apache.commons.configuration` with `org.apache.commons.configuration2` in `container.xml`.
- Update imports from `org.apache.commons.lang` to `org.apache.commons.lang3`.
- Modify character encoding usage to `java.nio.charset.StandardCharsets`.

fixes CVE-2025-48924