### PR TITLE
chore: bump Bloomreach CMS parent to 16.9.0

### DIFF
--- a/demo/pom.xml
+++ b/demo/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.onehippo.cms7</groupId>
     <artifactId>hippo-cms7-release</artifactId>
-    <version>16.7.0</version>
+    <version>16.9.0</version>
   </parent>
 
   <name>My Project</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.onehippo.cms7</groupId>
         <artifactId>hippo-cms7-project</artifactId>
-        <version>16.7.0</version>
+        <version>16.9.0</version>
     </parent>
 
     <name>Bloomreach Unit Testing Library</name>


### PR DESCRIPTION
Resolves GHSA-72hv-8253-57qq (jackson-core async parser DoS). 16.7.0 shipped jackson 2.19.4, which falls in the affected range (>=2.19.0, <2.21.1). 16.9.0 BOM upgrades jackson to a patched version.
Both plugin and demo parent POMs updated; full test suite passes.

(co-authored with Claude Code)